### PR TITLE
feat: center map on Big Ben, remove auto-isochrone on load

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ if (window.visualViewport) {
   window.visualViewport.addEventListener('scroll', syncAppHeight);
 }
 
-var map = L.map('map', { zoomControl: false }).setView([51.4871, 0.0371], 13);
+var map = L.map('map', { zoomControl: false }).setView([51.5007, -0.1246], 13);
 L.control.zoom({ position: 'topright' }).addTo(map);
 
 var isDark = false;
@@ -142,6 +142,17 @@ var isoLayers = [];
 var mode = 'walking';
 var center = null;
 var postcodeLayer = null;
+
+function placeDefaultMarker() {
+  var lat = 51.5007, lng = -0.1246;
+  var markerFill = isDark ? '#fff' : '#1a1a1a';
+  var markerRing = isDark ? 'rgba(255,255,255,0.4)' : 'rgba(255,255,255,0.9)';
+  marker = L.circleMarker([lat, lng], {
+    radius: 6, fillColor: markerFill, fillOpacity: 1,
+    color: markerRing, weight: 8
+  }).addTo(map);
+  document.querySelectorAll('.slot-val').forEach(function(el) { el.classList.add('empty'); });
+}
 
 map.on('mousemove', function(e) {
   document.getElementById('coords').textContent = e.latlng.lat.toFixed(4) + '\u00B0N, ' + e.latlng.lng.toFixed(4) + '\u00B0E';
@@ -366,8 +377,8 @@ async function run(lng, lat, label) {
     MINS.forEach(function(m) {
       var el = document.getElementById('a' + m);
       var a = areas[m];
-      if (a !== undefined && a > 0) { el.textContent = a >= 1 ? Math.round(a) + ' km\u00B2' : (a * 1000).toFixed(0) + ' m\u00B2'; }
-      else { el.textContent = '\u2014'; }
+      if (a !== undefined && a > 0) { el.textContent = a >= 1 ? Math.round(a) + ' km\u00B2' : (a * 1000).toFixed(0) + ' m\u00B2'; el.classList.remove('empty'); }
+      else { el.textContent = '\u2014'; el.classList.add('empty'); }
     });
 
     setStatus(label || lat.toFixed(4) + '\u00B0N, ' + lng.toFixed(4) + '\u00B0E');
@@ -398,4 +409,4 @@ function setStatus(msg, isError) {
   el.className = 'status' + (isError ? ' error' : '');
 }
 
-run(0.0371, 51.4871, 'The Valley, Charlton');
+placeDefaultMarker();

--- a/index.html
+++ b/index.html
@@ -102,10 +102,10 @@
   </div>
   <div class="section-label">Reachable area</div>
   <div class="slots">
-    <div class="slot"><div class="dot" style="color:#2ecc71;background:#2ecc71"></div><div class="slot-label">5 min</div><div class="slot-val" id="a5">&mdash;</div></div>
-    <div class="slot"><div class="dot" style="color:#3498db;background:#3498db"></div><div class="slot-label">10 min</div><div class="slot-val" id="a10">&mdash;</div></div>
-    <div class="slot"><div class="dot" style="color:#f39c12;background:#f39c12"></div><div class="slot-label">15 min</div><div class="slot-val" id="a15">&mdash;</div></div>
-    <div class="slot"><div class="dot" style="color:#e74c3c;background:#e74c3c"></div><div class="slot-label">20 min</div><div class="slot-val" id="a20">&mdash;</div></div>
+    <div class="slot"><div class="dot" style="color:#2ecc71;background:#2ecc71"></div><div class="slot-label">5 min</div><div class="slot-val empty" id="a5">&mdash;</div></div>
+    <div class="slot"><div class="dot" style="color:#3498db;background:#3498db"></div><div class="slot-label">10 min</div><div class="slot-val empty" id="a10">&mdash;</div></div>
+    <div class="slot"><div class="dot" style="color:#f39c12;background:#f39c12"></div><div class="slot-label">15 min</div><div class="slot-val empty" id="a15">&mdash;</div></div>
+    <div class="slot"><div class="dot" style="color:#e74c3c;background:#e74c3c"></div><div class="slot-label">20 min</div><div class="slot-val empty" id="a20">&mdash;</div></div>
   </div>
   <div class="divider"></div>
   <div class="section-label">Search location</div>
@@ -113,7 +113,7 @@
     <input class="sinput" id="q" autocomplete="off" placeholder="e.g. SE7 7PJ, Covent Garden, Big Ben…">
     <div class="suggestions" id="sugg"></div>
   </div>
-  <div class="status" id="st">Click anywhere on the map to start</div>
+  <div class="status" id="st">Search a place to see how far you can go</div>
   </div>
   <div class="postcode-view">
     <div class="panel-sub">Enter a UK postcode to see its boundary on the map.</div>
@@ -137,7 +137,7 @@
   </div>
   <div class="search-overlay-list" id="overlay-sugg"></div>
 </div>
-<div class="coord-display" id="coords">51.4871°N, 0.0371°E</div>
+<div class="coord-display" id="coords">51.5007°N, 0.1246°W</div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.js"></script>
 <script src="app.js"></script>

--- a/style.css
+++ b/style.css
@@ -68,6 +68,7 @@
   .dot { width: 8px; height: 8px; border-radius: 50%; margin: 0 auto 7px; box-shadow: 0 0 8px currentColor; }
   .slot-label { font-size: 10px; color: var(--text-dim); margin-bottom: 3px; }
   .slot-val { font-size: 14px; font-weight: 600; color: var(--text); font-variant-numeric: tabular-nums; }
+  .slot-val.empty { opacity: 0.4; }
   .divider { height: 1px; background: var(--divider); margin: 2px 0 14px; }
   .sinput { width: 100%; padding: 10px 12px; border: 1px solid var(--btn-border); border-radius: 10px; background: var(--input-bg); color: var(--text); font-family: 'DM Sans', sans-serif; font-size: 13px; outline: none; margin-bottom: 8px; transition: all 0.2s; }
   .sinput::placeholder { color: var(--input-placeholder); }


### PR DESCRIPTION
## Summary

Closes #5.

- Move default map center from Charlton to Big Ben (51.5007, -0.1246)
- Remove the auto-isochrone fetch on page load — zones only appear after a search
- Show a theme-colored dot marker at Big Ben as a visual anchor (white halo for tile contrast)
- Update status text from "Click anywhere on the map to start" → "Search a place to see how far you can go"
- Dim empty area value dashes (opacity 0.4) so they read as "no data yet"
- `center` left as `null` on load — prevents mode buttons from accidentally triggering API calls

## Test plan

- [ ] Map centers on Big Ben at zoom 13
- [ ] Theme dot visible with white halo, no zones rendered
- [ ] Status says "Search a place to see how far you can go"
- [ ] Area dashes are dimmed
- [ ] Toggle dark/light — dot color adapts
- [ ] Tapping Walk/Cycle/Drive does NOT generate zones
- [ ] Search a location → zones appear, dot replaced, dashes get full opacity
- [ ] Verify on `dev.ldnmap.pages.dev` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)