### PR TITLE
fix: remove map click listener that triggered unwanted isochrone fetches

### DIFF
--- a/app.js
+++ b/app.js
@@ -147,7 +147,6 @@ map.on('mousemove', function(e) {
   document.getElementById('coords').textContent = e.latlng.lat.toFixed(4) + '\u00B0N, ' + e.latlng.lng.toFixed(4) + '\u00B0E';
 });
 
-map.on('click', function(e) { run(e.latlng.lng, e.latlng.lat); });
 
 function pick(m) {
   mode = m;


### PR DESCRIPTION
Merges dev → main after verifying on dev.ldnmap.pages.dev.

Includes fix from #6: removes `map.on('click', ...)` so map taps no longer trigger isochrone API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)