### PR TITLE
feat: replace persistent panel with floating search pill

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,10 +7,6 @@ function syncAppHeight() {
   var vv = window.visualViewport;
   var h = (vv && vv.height) || window.innerHeight;
   document.documentElement.style.setProperty('--app-h', h + 'px');
-  if (vv && window.matchMedia('(max-width: 768px)').matches) {
-    var panelBottom = window.innerHeight - vv.offsetTop - vv.height + 8;
-    document.documentElement.style.setProperty('--panel-bottom', Math.max(8, panelBottom) + 'px');
-  }
 }
 syncAppHeight();
 window.addEventListener('resize', syncAppHeight);
@@ -24,44 +20,26 @@ L.control.zoom({ position: 'topright' }).addTo(map);
 
 var isDark = false;
 var tileLayer = null;
-function toggleSidebar() {
-  var panel = document.querySelector('.panel');
-  var showBtn = document.getElementById('show-btn');
-  var collapsed = panel.classList.toggle('collapsed');
-  showBtn.classList.toggle('hidden', !collapsed);
-  if (!collapsed && window.matchMedia('(max-width: 768px)').matches) {
-    showMenuView();
+
+var prevState = null;
+var appState = 'idle';
+function setState(newState) {
+  if (newState === appState) return;
+  prevState = appState;
+  appState = newState;
+  document.body.dataset.state = newState;
+  if (location.hostname === 'localhost' || location.port) {
+    console.log('[state] ' + prevState + ' → ' + newState);
   }
 }
-function showMenuView() {
-  var panel = document.querySelector('.panel');
-  panel.classList.add('view-menu');
-  panel.classList.remove('view-travel');
-  panel.classList.remove('view-postcode');
-  if (postcodeLayer) { map.removeLayer(postcodeLayer); postcodeLayer = null; }
-}
-function showTravelView() {
-  var panel = document.querySelector('.panel');
-  panel.classList.add('view-travel');
-  panel.classList.remove('view-menu', 'view-postcode');
-  document.querySelectorAll('.mode-tab').forEach(function(b) {
-    b.classList.toggle('on', b.dataset.tab === 'travel');
-  });
-}
-function showPostcodeView() {
-  var panel = document.querySelector('.panel');
-  panel.classList.add('view-postcode');
-  panel.classList.remove('view-menu', 'view-travel');
-  document.querySelectorAll('.mode-tab').forEach(function(b) {
-    b.classList.toggle('on', b.dataset.tab === 'postcode');
-  });
-}
+
 function searchPostcode() {
   var pcEl = document.getElementById('pc-input');
-  var pc = (overlaySourceInput === pcEl ? overlayInput.value : pcEl.value).trim().toUpperCase();
-  if (overlaySourceInput) { pcEl.value = pc; closeSearchOverlay(); }
+  if (!pcEl) return;
+  var pc = pcEl.value.trim().toUpperCase();
   if (!pc) return;
   var statusEl = document.getElementById('pc-status');
+  if (!statusEl) return;
   statusEl.className = 'status';
   statusEl.textContent = 'Fetching ' + pc + '…';
 
@@ -110,12 +88,9 @@ function renderPostcode(geo, pc, statusEl) {
     + props.postcodedeliverypointcount_total + ' delivery points · '
     + geo.features.length + ' polygon part' + (geo.features.length > 1 ? 's' : '');
 }
-if (window.matchMedia('(max-width: 768px)').matches) {
-  document.querySelector('.panel').classList.add('collapsed');
-  document.getElementById('show-btn').classList.remove('hidden');
-} else {
-  showTravelView();
-}
+
+setState('idle');
+
 function initTile() {
   var style = isDark ? 'dark-v11' : 'streets-v12';
   if (tileLayer) map.removeLayer(tileLayer);
@@ -130,7 +105,6 @@ function toggleTheme() {
   var iconHtml = isDark
     ? '<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>'
     : '<circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/>';
-  document.getElementById('theme-icon').innerHTML = iconHtml;
   var fab = document.getElementById('theme-icon-fab');
   if (fab) fab.innerHTML = iconHtml;
   initTile();
@@ -151,13 +125,11 @@ function placeDefaultMarker() {
     radius: 6, fillColor: markerFill, fillOpacity: 1,
     color: markerRing, weight: 8
   }).addTo(map);
-  document.querySelectorAll('.slot-val').forEach(function(el) { el.classList.add('empty'); });
 }
 
 map.on('mousemove', function(e) {
-  document.getElementById('coords').textContent = e.latlng.lat.toFixed(4) + '\u00B0N, ' + e.latlng.lng.toFixed(4) + '\u00B0E';
+  document.getElementById('coords').textContent = e.latlng.lat.toFixed(4) + '°N, ' + e.latlng.lng.toFixed(4) + '°E';
 });
-
 
 function pick(m) {
   mode = m;
@@ -169,27 +141,21 @@ var sessionToken = (crypto && crypto.randomUUID) ? crypto.randomUUID() : String(
 var suggestTimer = null;
 var currentSuggestions = [];
 var activeIdx = -1;
-var qInput = document.getElementById('q');
-var suggBox = document.getElementById('sugg');
-var origSuggBox = suggBox;
 
-var overlaySourceInput = null;
 var overlayInput = document.getElementById('overlay-input');
 var overlaySugg = document.getElementById('overlay-sugg');
 var overlayEl = document.getElementById('search-overlay');
-var panelEl = document.querySelector('.panel');
+var suggBox = overlaySugg;
 
-function closeSugg() { if (overlaySourceInput) { activeIdx = -1; return; } suggBox.classList.remove('open'); activeIdx = -1; }
-function openSugg() { if (overlaySourceInput) return; if (currentSuggestions.length) suggBox.classList.add('open'); }
+function closeSugg() { activeIdx = -1; }
+function openSugg() { if (currentSuggestions.length) renderSuggestions(); }
 
-function openSearchOverlay(sourceInput) {
-  if (!window.matchMedia('(max-width: 768px)').matches) return;
-  overlaySourceInput = sourceInput;
-  overlayInput.value = sourceInput.value;
-  overlayInput.placeholder = sourceInput.placeholder;
-  suggBox = overlaySugg;
-  panelEl.classList.add('search-active');
-  if (currentSuggestions.length) renderSuggestions();
+function openSearchOverlay() {
+  setState('search');
+  overlayInput.value = '';
+  overlayInput.placeholder = 'Search a place…';
+  currentSuggestions = [];
+  overlaySugg.innerHTML = '';
   requestAnimationFrame(function() {
     overlayEl.classList.add('open');
     overlayInput.focus();
@@ -197,18 +163,11 @@ function openSearchOverlay(sourceInput) {
 }
 
 function closeSearchOverlay() {
-  if (!overlaySourceInput) return;
   overlayInput.blur();
   overlayEl.classList.remove('open');
-  overlaySourceInput.value = overlayInput.value;
-  var src = overlaySourceInput;
-  overlaySourceInput = null;
-  suggBox = origSuggBox;
   currentSuggestions = [];
   overlaySugg.innerHTML = '';
-  requestAnimationFrame(function() {
-    panelEl.classList.remove('search-active');
-  });
+  setState('idle');
 }
 
 function renderSuggestions() {
@@ -247,10 +206,8 @@ async function fetchSuggest(q) {
 async function selectSuggestion(i) {
   var s = currentSuggestions[i];
   if (!s) return;
-  qInput.value = s.name;
-  if (overlaySourceInput) closeSearchOverlay();
-  closeSugg();
-  setStatus('Loading\u2026');
+  closeSearchOverlay();
+  setStatus('Loading…');
   try {
     var url = 'https://api.mapbox.com/search/searchbox/v1/retrieve/' + encodeURIComponent(s.mapbox_id)
       + '?session_token=' + sessionToken + '&access_token=' + MAPBOX_TOKEN;
@@ -266,51 +223,9 @@ async function selectSuggestion(i) {
   } catch (e) { setStatus('Search failed', true); }
 }
 
-qInput.addEventListener('input', function() {
-  var q = qInput.value.trim();
-  clearTimeout(suggestTimer);
-  if (!q) { currentSuggestions = []; closeSugg(); return; }
-  suggestTimer = setTimeout(function() { fetchSuggest(q); }, 180);
-});
-
-qInput.addEventListener('keydown', function(e) {
-  if (!suggBox.classList.contains('open')) return;
-  if (e.key === 'ArrowDown') {
-    e.preventDefault();
-    activeIdx = Math.min(activeIdx + 1, currentSuggestions.length - 1);
-    renderSuggestions();
-  } else if (e.key === 'ArrowUp') {
-    e.preventDefault();
-    activeIdx = Math.max(activeIdx - 1, 0);
-    renderSuggestions();
-  } else if (e.key === 'Enter') {
-    e.preventDefault();
-    selectSuggestion(activeIdx >= 0 ? activeIdx : 0);
-  } else if (e.key === 'Escape') {
-    closeSugg();
-  }
-});
-
-qInput.addEventListener('focus', function() {
-  if (window.matchMedia('(max-width: 768px)').matches) { openSearchOverlay(qInput); return; }
-  if (currentSuggestions.length) openSugg();
-});
-
-document.addEventListener('click', function(e) {
-  if (overlaySourceInput) return;
-  if (!e.target.closest('.search-wrap')) closeSugg();
-});
-
-var pcInput = document.getElementById('pc-input');
-pcInput.addEventListener('focus', function() { openSearchOverlay(pcInput); });
-pcInput.addEventListener('keydown', function(e) {
-  if (e.key === 'Enter') searchPostcode();
-});
-
 document.getElementById('search-back-btn').addEventListener('click', closeSearchOverlay);
 
 overlayInput.addEventListener('input', function() {
-  if (overlaySourceInput === pcInput) return;
   var q = overlayInput.value.trim();
   clearTimeout(suggestTimer);
   if (!q) { currentSuggestions = []; overlaySugg.innerHTML = ''; return; }
@@ -318,11 +233,6 @@ overlayInput.addEventListener('input', function() {
 });
 
 overlayInput.addEventListener('keydown', function(e) {
-  if (overlaySourceInput === pcInput) {
-    if (e.key === 'Enter') searchPostcode();
-    if (e.key === 'Escape') closeSearchOverlay();
-    return;
-  }
   if (e.key === 'Escape') { closeSearchOverlay(); return; }
   if (!currentSuggestions.length) return;
   if (e.key === 'ArrowDown') {
@@ -338,11 +248,10 @@ overlayInput.addEventListener('keydown', function(e) {
     selectSuggestion(activeIdx >= 0 ? activeIdx : 0);
   }
 });
-document.getElementById('pc-year').textContent = new Date().getFullYear();
 
 async function run(lng, lat, label) {
   center = [lng, lat];
-  setStatus('Loading isochrones\u2026');
+  setStatus('Loading isochrones…');
 
   if (marker) map.removeLayer(marker);
   var markerFill = isDark ? '#fff' : '#1a1a1a';
@@ -375,12 +284,13 @@ async function run(lng, lat, label) {
     data.features.forEach(function(f) { areas[f.properties.contour] = calcArea(f.geometry); });
     MINS.forEach(function(m) {
       var el = document.getElementById('a' + m);
+      if (!el) return;
       var a = areas[m];
-      if (a !== undefined && a > 0) { el.textContent = a >= 1 ? Math.round(a) + ' km\u00B2' : (a * 1000).toFixed(0) + ' m\u00B2'; el.classList.remove('empty'); }
-      else { el.textContent = '\u2014'; el.classList.add('empty'); }
+      if (a !== undefined && a > 0) { el.textContent = a >= 1 ? Math.round(a) + ' km²' : (a * 1000).toFixed(0) + ' m²'; el.classList.remove('empty'); }
+      else { el.textContent = '—'; el.classList.add('empty'); }
     });
 
-    setStatus(label || lat.toFixed(4) + '\u00B0N, ' + lng.toFixed(4) + '\u00B0E');
+    setStatus(label || lat.toFixed(4) + '°N, ' + lng.toFixed(4) + '°E');
   } catch(e) { setStatus('Failed to load isochrones', true); }
 }
 
@@ -404,8 +314,7 @@ function ringArea(rings) {
 function rad(d) { return d * Math.PI / 180; }
 function setStatus(msg, isError) {
   var el = document.getElementById('st');
+  if (!el) return;
   el.textContent = msg;
   el.className = 'status' + (isError ? ' error' : '');
 }
-
-placeDefaultMarker();

--- a/index.html
+++ b/index.html
@@ -11,121 +11,17 @@
 </head>
 <body class="light">
 <div id="map"></div>
-<button id="show-btn" class="show-btn hidden" onclick="toggleSidebar()" title="Show sidebar" aria-label="Show sidebar">
-  <span class="explore-label">Explore</span>
+<button id="search-pill" onclick="openSearchOverlay()">
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-    <polyline class="chev-right" points="9 18 15 12 9 6"/>
-    <polyline class="chev-up" points="6 15 12 9 18 15"/>
+    <circle cx="11" cy="11" r="7"/><path d="M21 21l-4.5-4.5"/>
   </svg>
+  <span class="pill-label">Search a place&hellip;</span>
 </button>
 <button class="theme-fab" onclick="toggleTheme()" title="Toggle theme" aria-label="Toggle theme">
   <svg id="theme-icon-fab" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
   </svg>
 </button>
-<div class="panel view-menu">
-  <div class="panel-header">
-    <button class="back-btn" onclick="showMenuView()" aria-label="Back to modes">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <polyline points="15 18 9 12 15 6"/>
-      </svg>
-      Modes
-    </button>
-    <div class="panel-title">ldnmap</div>
-    <button class="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark" aria-label="Toggle theme">
-      <svg id="theme-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-      </svg>
-    </button>
-    <button class="collapse-btn" onclick="toggleSidebar()" title="Hide sidebar" aria-label="Hide sidebar">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <polyline points="15 18 9 12 15 6"/>
-      </svg>
-    </button>
-  </div>
-  <div class="mode-grid" aria-label="Map modes">
-    <button class="mode-tile active" data-mode="travel" aria-label="Travel time" onclick="showTravelView()">
-      <svg class="tile-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-        <circle cx="12" cy="4.5" r="1.8"/>
-        <path d="M10 22l2-7 3 3v6"/>
-        <path d="M14 13l2-3-3-3-2 4-3 1"/>
-      </svg>
-      <span class="tile-label">Travel time</span>
-    </button>
-    <button class="mode-tile" data-mode="postcode" aria-label="Postcode area" onclick="showPostcodeView()">
-      <svg class="tile-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-        <rect x="3" y="5" width="18" height="14" rx="2"/>
-        <path d="M3 9h18"/>
-        <path d="M8 5V3M16 5V3"/>
-      </svg>
-      <span class="tile-label">Postcode</span>
-    </button>
-    <button class="mode-tile disabled" data-mode="nearby" aria-label="Nearby (coming soon)" aria-disabled="true">
-      <svg class="tile-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-        <circle cx="11" cy="11" r="7"/>
-        <path d="M21 21l-4.5-4.5"/>
-      </svg>
-      <span class="tile-label">Nearby</span>
-      <span class="soon-badge">Soon</span>
-    </button>
-    <button class="mode-tile disabled" data-mode="style" aria-label="Style (coming soon)" aria-disabled="true">
-      <svg class="tile-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M12 3a9 9 0 1 0 0 18c1.5 0 2-1 2-2 0-1.5-1-2-1-3s1-1.5 2-1.5h2a4 4 0 0 0 4-4 9 9 0 0 0-9-7.5z"/>
-        <circle cx="7.5" cy="10.5" r="1"/>
-        <circle cx="12" cy="7.5" r="1"/>
-        <circle cx="16.5" cy="10.5" r="1"/>
-      </svg>
-      <span class="tile-label">Style</span>
-      <span class="soon-badge">Soon</span>
-    </button>
-  </div>
-  <div class="mode-tabs">
-    <button class="mode-tab on" data-tab="travel" onclick="showTravelView()">Travel time</button>
-    <button class="mode-tab" data-tab="postcode" onclick="showPostcodeView()">Postcode</button>
-  </div>
-  <div class="travel-view">
-  <div class="panel-sub">Click the map or search a location to see how far you can travel</div>
-  <div class="section-label">Travel mode</div>
-  <div class="modes">
-    <button class="mbtn on" data-m="walking" onclick="pick('walking')">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="5" r="2"/><path d="M10 22l2-7 3 3v6M14 13l2-3-3-3-2 4"/></svg>
-      Walk
-    </button>
-    <button class="mbtn" data-m="cycling" onclick="pick('cycling')">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="6" cy="17" r="3"/><circle cx="18" cy="17" r="3"/><path d="M6 17l3-7h4l3 7M9 7h4l-1 3"/></svg>
-      Cycle
-    </button>
-    <button class="mbtn" data-m="driving" onclick="pick('driving')">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="8" width="18" height="10" rx="2"/><path d="M5 8l2-4h10l2 4M7 14h.01M17 14h.01"/></svg>
-      Drive
-    </button>
-  </div>
-  <div class="section-label">Reachable area</div>
-  <div class="slots">
-    <div class="slot"><div class="dot" style="color:#2ecc71;background:#2ecc71"></div><div class="slot-label">5 min</div><div class="slot-val empty" id="a5">&mdash;</div></div>
-    <div class="slot"><div class="dot" style="color:#3498db;background:#3498db"></div><div class="slot-label">10 min</div><div class="slot-val empty" id="a10">&mdash;</div></div>
-    <div class="slot"><div class="dot" style="color:#f39c12;background:#f39c12"></div><div class="slot-label">15 min</div><div class="slot-val empty" id="a15">&mdash;</div></div>
-    <div class="slot"><div class="dot" style="color:#e74c3c;background:#e74c3c"></div><div class="slot-label">20 min</div><div class="slot-val empty" id="a20">&mdash;</div></div>
-  </div>
-  <div class="divider"></div>
-  <div class="section-label">Search location</div>
-  <div class="search-wrap">
-    <input class="sinput" id="q" autocomplete="off" placeholder="e.g. SE7 7PJ, Covent Garden, Big Ben…">
-    <div class="suggestions" id="sugg"></div>
-  </div>
-  <div class="status" id="st">Search a place to see how far you can go</div>
-  </div>
-  <div class="postcode-view">
-    <div class="panel-sub">Enter a UK postcode to see its boundary on the map.</div>
-    <div class="section-label">Postcode</div>
-    <div class="search-wrap pc-search-wrap">
-      <input class="sinput" id="pc-input" autocomplete="off" spellcheck="false" placeholder="e.g. W14 8DD, SW1A 1AA">
-      <button class="pc-search-btn" onclick="searchPostcode()">Show</button>
-    </div>
-    <div class="status" id="pc-status">Try: W14 8DD · SW1A 1AA · EC1A 1BB</div>
-    <div class="pc-attribution">Boundaries &copy; Crown copyright &amp; database right <span id="pc-year"></span> OS Data Hub</div>
-  </div>
-</div>
 <div id="search-overlay" class="search-overlay">
   <div class="search-overlay-header">
     <button class="search-overlay-back" id="search-back-btn">

--- a/style.css
+++ b/style.css
@@ -15,7 +15,6 @@
     --glass-shadow: 0 -8px 32px rgba(0,0,0,0.32); --glass-fab-bg: rgba(28,28,30,0.6);
     --glass-solid-fallback: rgba(20,20,22,0.96);
     --glass-tile-bg: rgba(255,255,255,0.10); --glass-tile-active: rgba(255,255,255,0.18);
-    --soon-badge-bg: rgba(255,255,255,0.14); --soon-badge-text: rgba(255,255,255,0.7);
   }
   body.light {
     --bg: #f0f0f0; --panel-bg: rgba(255,255,255,0.92); --panel-border: rgba(0,0,0,0.08);
@@ -33,53 +32,45 @@
     --glass-shadow: 0 -8px 32px rgba(0,0,0,0.10); --glass-fab-bg: rgba(255,255,255,0.7);
     --glass-solid-fallback: rgba(250,250,252,0.98);
     --glass-tile-bg: rgba(255,255,255,0.45); --glass-tile-active: rgba(255,255,255,0.75);
-    --soon-badge-bg: rgba(0,0,0,0.08); --soon-badge-text: rgba(0,0,0,0.55);
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
   html, body { position: fixed; inset: 0; width: 100%; height: 100%; overflow: hidden; overscroll-behavior: none; -webkit-overflow-scrolling: auto; }
   body { font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif; background: var(--bg); color: var(--text-soft); height: var(--app-h, 100dvh); transition: background 0.3s, color 0.3s; }
   #map { position: absolute; top: 0; left: 0; right: 0; bottom: 0; z-index: 1; }
-  .panel { position: absolute; top: 16px; left: 16px; bottom: 16px; z-index: 1000; background: var(--panel-bg); backdrop-filter: blur(24px); -webkit-backdrop-filter: blur(24px); border: 1px solid var(--panel-border); border-radius: 16px; padding: 22px; width: 320px; box-shadow: 0 8px 40px rgba(0,0,0,0.12); display: flex; flex-direction: column; transition: transform 0.3s cubic-bezier(.4,0,.2,1), opacity 0.3s, background 0.3s, border-color 0.3s; animation: fadeIn 0.4s ease; }
-  .panel.collapsed { transform: translateX(calc(-100% - 24px)); opacity: 0; pointer-events: none; }
-  .panel-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px; gap: 6px; }
-  .panel-title { font-size: 16px; font-weight: 700; color: var(--text); letter-spacing: -0.4px; flex: 1; }
-  .panel-badge { font-size: 10px; font-weight: 600; background: rgba(46,204,113,0.15); color: #2ecc71; padding: 3px 8px; border-radius: 6px; letter-spacing: 0.3px; }
-  .theme-toggle, .collapse-btn { background: none; border: 1px solid var(--btn-border); border-radius: 8px; padding: 5px 7px; cursor: pointer; color: var(--text-dim); transition: all 0.2s; display: flex; align-items: center; justify-content: center; }
-  .theme-toggle:hover, .collapse-btn:hover { border-color: var(--btn-hover-border); color: var(--text); }
-  .theme-toggle svg, .collapse-btn svg { width: 14px; height: 14px; }
-  .show-btn { position: absolute; top: 16px; left: 16px; z-index: 1000; width: 44px; height: 44px; border-radius: 50%; background: var(--panel-bg); border: 1px solid var(--panel-border); box-shadow: 0 4px 16px rgba(0,0,0,0.12); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); cursor: pointer; color: var(--text); display: flex; align-items: center; justify-content: center; transition: opacity 0.3s, transform 0.3s; }
-  .show-btn:hover { color: var(--text); }
-  .show-btn.hidden { opacity: 0; pointer-events: none; transform: translateX(-20px); }
-  .show-btn svg { width: 18px; height: 18px; }
-  .show-btn .chev-up { display: none; }
-  .show-btn .explore-label { display: none; }
-  .theme-fab { display: none; }
-  .panel-sub { font-size: 12px; color: var(--text-dim); margin-bottom: 20px; line-height: 1.4; }
-  .section-label { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px; color: var(--text-faint); margin-bottom: 8px; }
-  .modes { display: flex; gap: 6px; margin-bottom: 18px; }
-  .mbtn { flex: 1; padding: 9px 0; border: 1px solid var(--btn-border); border-radius: 10px; background: transparent; color: var(--mbtn-text); font-family: 'DM Sans', sans-serif; font-size: 12px; font-weight: 500; cursor: pointer; transition: all 0.2s ease; display: flex; align-items: center; justify-content: center; gap: 5px; }
-  .mbtn:hover { border-color: var(--btn-hover-border); color: var(--mbtn-hover-text); background: var(--btn-hover-bg); }
-  .mbtn.on { background: var(--btn-on-bg); border-color: var(--btn-on-border); color: var(--text); }
-  .mbtn svg { width: 14px; height: 14px; opacity: 0.7; }
-  .mbtn.on svg { opacity: 1; }
-  .slots { display: grid; grid-template-columns: repeat(4,1fr); gap: 6px; margin-bottom: 18px; }
-  .slot { text-align: center; padding: 12px 4px 10px; border-radius: 12px; border: 1px solid var(--slot-border); background: var(--slot-bg); transition: border-color 0.2s; }
-  .slot:hover { border-color: var(--slot-hover-border); }
-  .dot { width: 8px; height: 8px; border-radius: 50%; margin: 0 auto 7px; box-shadow: 0 0 8px currentColor; }
-  .slot-label { font-size: 10px; color: var(--text-dim); margin-bottom: 3px; }
-  .slot-val { font-size: 14px; font-weight: 600; color: var(--text); font-variant-numeric: tabular-nums; }
-  .slot-val.empty { opacity: 0.4; }
-  .divider { height: 1px; background: var(--divider); margin: 2px 0 14px; }
+  #search-pill {
+    position: absolute; top: 16px; left: 16px; z-index: 1000;
+    display: flex; align-items: center; gap: 8px;
+    height: 48px; padding: 0 20px;
+    border-radius: 24px; border: 1px solid var(--glass-border);
+    background: var(--glass-pill-bg);
+    backdrop-filter: blur(40px) saturate(180%);
+    -webkit-backdrop-filter: blur(40px) saturate(180%);
+    box-shadow: inset 0 1px 0 0 var(--glass-highlight), 0 4px 16px rgba(0,0,0,0.12);
+    color: var(--text-dim); font-family: 'DM Sans', sans-serif;
+    font-size: 14px; font-weight: 500; cursor: pointer;
+    transition: transform 0.2s, opacity 0.3s;
+  }
+  #search-pill:active { transform: scale(0.97); }
+  #search-pill svg { width: 18px; height: 18px; flex-shrink: 0; }
+  body[data-state="search"] #search-pill { opacity: 0; pointer-events: none; }
+  #search-pill.icon-only .pill-label { display: none; }
+  #search-pill.icon-only { padding: 0; width: 48px; justify-content: center; }
+  .theme-fab {
+    display: flex; position: absolute; top: 16px; right: 16px; z-index: 1000;
+    width: 40px; height: 40px; border-radius: 20px;
+    background: var(--glass-fab-bg);
+    backdrop-filter: blur(30px) saturate(180%);
+    -webkit-backdrop-filter: blur(30px) saturate(180%);
+    border: 1px solid var(--glass-border);
+    box-shadow: inset 0 1px 0 0 var(--glass-highlight), 0 4px 16px rgba(0,0,0,0.12);
+    align-items: center; justify-content: center; cursor: pointer; color: var(--text);
+    transition: transform 0.2s, background 0.3s;
+  }
+  .theme-fab:active { transform: scale(0.94); }
+  .theme-fab svg { width: 18px; height: 18px; }
   .sinput { width: 100%; padding: 10px 12px; border: 1px solid var(--btn-border); border-radius: 10px; background: var(--input-bg); color: var(--text); font-family: 'DM Sans', sans-serif; font-size: 13px; outline: none; margin-bottom: 8px; transition: all 0.2s; }
   .sinput::placeholder { color: var(--input-placeholder); }
   .sinput:focus { border-color: var(--btn-on-border); background: var(--input-focus-bg); }
-  .sbtn { width: 100%; padding: 10px; border: none; border-radius: 10px; background: var(--sbtn-bg); color: var(--sbtn-text); font-family: 'DM Sans', sans-serif; font-size: 13px; font-weight: 600; cursor: pointer; transition: all 0.2s; }
-  .sbtn:hover { opacity: 0.88; transform: translateY(-1px); }
-  .sbtn:active { transform: translateY(0); }
-  .sbtn:disabled { opacity: 0.3; cursor: not-allowed; transform: none; }
-  .search-wrap { position: relative; }
-  .suggestions { position: absolute; top: calc(100% + 4px); left: 0; right: 0; background: var(--panel-bg); border: 1px solid var(--panel-border); border-radius: 10px; box-shadow: 0 8px 24px rgba(0,0,0,0.18); backdrop-filter: blur(20px); max-height: 280px; overflow-y: auto; z-index: 1100; display: none; }
-  .suggestions.open { display: block; }
   .sugg-item { padding: 9px 12px; cursor: pointer; border-bottom: 1px solid var(--panel-border); }
   .sugg-item:last-child { border-bottom: none; }
   .sugg-item:hover, .sugg-item.active { background: var(--input-focus-bg); }
@@ -96,181 +87,55 @@
   .leaflet-control-attribution { background: var(--attrib-bg) !important; color: var(--attrib-text) !important; font-size: 10px !important; backdrop-filter: blur(8px) !important; border-radius: 6px 0 0 0 !important; padding: 3px 8px !important; }
   .leaflet-control-attribution a { color: var(--attrib-link) !important; }
   .coord-display { position: absolute; bottom: 28px; left: 16px; z-index: 1000; font-size: 11px; color: var(--text-dim); background: var(--coord-bg); padding: 4px 10px; border-radius: 8px; backdrop-filter: blur(8px); font-variant-numeric: tabular-nums; }
-  .mode-grid { display: none; }
-  .back-btn { display: none; }
-  .postcode-view { display: none; }
-  .mode-tabs { display: flex; gap: 6px; margin-bottom: 14px; }
-  .mode-tab {
-    flex: 1; padding: 9px 0; border: 1px solid var(--btn-border); border-radius: 10px;
-    background: transparent; color: var(--mbtn-text); font-family: 'DM Sans', sans-serif;
-    font-size: 12px; font-weight: 500; cursor: pointer; transition: all 0.2s ease;
+  .search-overlay {
+    position: fixed; inset: 0; z-index: 1200;
+    background: var(--glass-sheet-bg);
+    backdrop-filter: blur(40px) saturate(180%); -webkit-backdrop-filter: blur(40px) saturate(180%);
+    display: flex; flex-direction: column;
+    padding-top: env(safe-area-inset-top, 0px);
+    transform: translateY(100%); opacity: 0;
+    transition: transform 0.36s cubic-bezier(0.32, 0.72, 0, 1), opacity 0.28s ease;
+    pointer-events: none;
   }
-  .mode-tab.on {
-    background: var(--btn-on-bg); color: var(--btn-on-text);
-    border-color: var(--btn-on-border); font-weight: 600;
+  .search-overlay.open { transform: translateY(0); opacity: 1; pointer-events: auto; }
+  .search-overlay-header {
+    display: flex; align-items: center; gap: 8px;
+    padding: 14px 14px 10px;
+    border-bottom: 1px solid var(--glass-border); flex-shrink: 0;
   }
-  .panel.view-postcode .postcode-view { display: block; }
-  .panel.view-postcode .travel-view { display: none; }
-  .pc-search-wrap { display: flex; gap: 8px; align-items: center; }
-  .pc-search-btn {
-    flex-shrink: 0; font: inherit; font-size: 13px; font-weight: 500;
-    padding: 8px 14px; border-radius: 10px; cursor: pointer;
-    background: var(--accent, #2563eb); color: #fff;
-    border: none; letter-spacing: -0.1px;
-    transition: opacity 0.15s;
+  .search-overlay-back {
+    width: 36px; height: 36px; border-radius: 50%;
+    border: 1px solid var(--glass-border); background: var(--glass-tile-bg);
+    box-shadow: inset 0 1px 0 0 var(--glass-highlight);
+    color: var(--text); display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0; cursor: pointer;
   }
-  .pc-search-btn:active { opacity: 0.75; }
-  .pc-attribution { font-size: 10px; color: var(--text-dim); margin-top: 10px; }
-  .search-overlay { display: none; }
+  .search-overlay-back:active { opacity: 0.6; }
+  .search-overlay-back svg { width: 18px; height: 18px; }
+  .search-overlay-header .sinput { flex: 1; margin-bottom: 0; font-size: 16px; }
+  .search-overlay-list {
+    flex: 1; overflow-y: auto; -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain; padding: 8px 10px;
+    padding-bottom: max(16px, env(safe-area-inset-bottom, 16px));
+  }
+  .search-overlay-list .sugg-item { border-radius: 12px; border-bottom: none; margin-bottom: 2px; }
+  .search-overlay-list .sugg-item:hover, .search-overlay-list .sugg-item.active { background: var(--glass-tile-bg); }
   @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
   @media (max-width: 768px) {
-    .search-overlay { display: flex; }
-    .panel {
-      width: calc(100% - 16px); left: 8px; right: 8px; top: auto; bottom: var(--panel-bottom, 8px);
-      padding: 18px 18px 22px; border-radius: 24px;
-      max-height: calc(var(--app-h, 100dvh) - 16px);
-      overflow-y: auto; overscroll-behavior: contain;
-      background: var(--glass-sheet-bg);
-      backdrop-filter: blur(40px) saturate(180%);
-      -webkit-backdrop-filter: blur(40px) saturate(180%);
-      border: 1px solid var(--glass-border);
-      box-shadow: inset 0 1px 0 0 var(--glass-highlight), var(--glass-shadow);
-      transition: transform 0.4s cubic-bezier(0.32, 0.72, 0, 1), opacity 0.3s, background 0.3s;
+    #search-pill {
+      top: auto; bottom: 16px; left: 50%; transform: translateX(-50%);
     }
-    .panel.collapsed { transform: translateY(calc(100% + 24px)); opacity: 0; }
-    .panel-header .theme-toggle { display: none; }
-    .panel-header { margin-bottom: 8px; }
-    .panel-title { font-size: 17px; }
-    .show-btn {
-      top: auto; bottom: 16px; left: 50%;
-      transform: translateX(-50%);
-      width: auto; height: 44px;
-      border-radius: 22px; padding: 0 18px;
-      background: var(--glass-pill-bg);
-      backdrop-filter: blur(40px) saturate(180%);
-      -webkit-backdrop-filter: blur(40px) saturate(180%);
-      border: 1px solid var(--glass-border);
-      box-shadow: inset 0 1px 0 0 var(--glass-highlight), 0 8px 24px rgba(0,0,0,0.18);
-      justify-content: center; gap: 0;
-      transition: opacity 0.3s, transform 0.3s, background 0.3s;
-    }
-    .show-btn.hidden { transform: translate(-50%, 24px); }
-    .show-btn:active { transform: translate(-50%, 1px) scale(0.97); }
-    .show-btn .chev-right { display: none; }
-    .show-btn .chev-up { display: none; }
-    .show-btn svg { display: none; }
-    .show-btn .explore-label { display: inline; font-size: 14px; font-weight: 500; color: var(--text); letter-spacing: -0.1px; }
-    .theme-fab {
-      display: flex; position: absolute; top: 12px; left: 12px; z-index: 1000;
-      width: 40px; height: 40px; border-radius: 20px;
-      background: var(--glass-fab-bg);
-      backdrop-filter: blur(30px) saturate(180%);
-      -webkit-backdrop-filter: blur(30px) saturate(180%);
-      border: 1px solid var(--glass-border);
-      box-shadow: inset 0 1px 0 0 var(--glass-highlight), 0 4px 16px rgba(0,0,0,0.12);
-      align-items: center; justify-content: center; cursor: pointer; color: var(--text);
-      transition: transform 0.2s, background 0.3s;
-    }
-    .theme-fab:active { transform: scale(0.94); }
-    .theme-fab svg { width: 18px; height: 18px; }
+    #search-pill:active { transform: translateX(-50%) scale(0.97); }
+    .theme-fab { top: 12px; left: 12px; right: auto; }
     .coord-display { display: none; }
-    .panel-header { margin-bottom: 4px; }
-    .mode-grid {
-      display: grid; grid-template-columns: 1fr 1fr; gap: 10px;
-      margin-top: 4px; margin-bottom: 14px;
-    }
-    .mode-tile {
-      position: relative; aspect-ratio: 1; border-radius: 18px;
-      background: var(--glass-tile-bg);
-      border: 1px solid var(--glass-border);
-      box-shadow: inset 0 1px 0 0 var(--glass-highlight), 0 4px 14px rgba(0,0,0,0.08);
-      display: flex; flex-direction: column; align-items: center; justify-content: center;
-      gap: 6px; padding: 8px; cursor: pointer; color: var(--text);
-      font-family: 'DM Sans', sans-serif;
-      transition: background 0.2s, transform 0.15s;
-      overflow: hidden;
-    }
-    .mode-tile::before {
-      content: ""; position: absolute; inset: 0; border-radius: inherit;
-      background: linear-gradient(180deg, rgba(255,255,255,0.22) 0%, rgba(255,255,255,0.04) 32%, transparent 60%);
-      pointer-events: none;
-    }
-    .mode-tile.active { background: var(--glass-tile-active); }
-    .mode-tile:active:not(.disabled) { transform: scale(0.97); }
-    .mode-tile.disabled { opacity: 0.5; pointer-events: none; }
-    .mode-tile .tile-icon { width: 26px; height: 26px; opacity: 0.9; }
-    .mode-tile .tile-label { font-size: 12px; font-weight: 500; letter-spacing: -0.1px; }
-    .soon-badge {
-      position: absolute; top: 8px; right: 8px;
-      font-size: 9px; font-weight: 600; letter-spacing: 0.3px;
-      padding: 2px 6px; border-radius: 8px;
-      background: var(--soon-badge-bg); color: var(--soon-badge-text);
-      text-transform: uppercase;
-    }
     .sinput { font-size: 16px; }
-    .mode-tabs { display: none; }
-    .panel.view-menu .travel-view { display: none; }
-    .panel.view-menu .postcode-view { display: none; }
-    .panel.view-travel .mode-grid { display: none; }
-    .panel.view-postcode .mode-grid { display: none; }
-    .panel.view-travel .back-btn,
-    .panel.view-postcode .back-btn {
-      display: inline-flex; align-items: center; gap: 4px;
-      background: none; border: none; padding: 4px 6px 4px 0;
-      color: var(--text); font-family: 'DM Sans', sans-serif;
-      font-size: 14px; font-weight: 500; cursor: pointer;
-      letter-spacing: -0.1px;
-    }
-    .panel.view-travel .back-btn svg,
-    .panel.view-postcode .back-btn svg { width: 16px; height: 16px; }
-    .panel.view-travel .back-btn:active,
-    .panel.view-postcode .back-btn:active { opacity: 0.6; }
-    .panel.view-travel .panel-title,
-    .panel.view-postcode .panel-title { display: none; }
-    .panel.view-menu .panel-title { font-size: 17px; font-weight: 600; }
-    .panel.search-active { pointer-events: none; opacity: 0; transition: opacity 0.2s ease; }
-    .search-overlay {
-      position: fixed; inset: 0; z-index: 1200;
-      background: var(--glass-sheet-bg);
-      backdrop-filter: blur(40px) saturate(180%); -webkit-backdrop-filter: blur(40px) saturate(180%);
-      display: flex; flex-direction: column;
-      padding-top: env(safe-area-inset-top, 0px);
-      transform: translateY(100%); opacity: 0;
-      transition: transform 0.36s cubic-bezier(0.32, 0.72, 0, 1), opacity 0.28s ease;
-      pointer-events: none;
-    }
-    .search-overlay.open { transform: translateY(0); opacity: 1; pointer-events: auto; }
-    .search-overlay-header {
-      display: flex; align-items: center; gap: 8px;
-      padding: 14px 14px 10px;
-      border-bottom: 1px solid var(--glass-border); flex-shrink: 0;
-    }
-    .search-overlay-back {
-      width: 36px; height: 36px; border-radius: 50%;
-      border: 1px solid var(--glass-border); background: var(--glass-tile-bg);
-      box-shadow: inset 0 1px 0 0 var(--glass-highlight);
-      color: var(--text); display: flex; align-items: center; justify-content: center;
-      flex-shrink: 0; cursor: pointer;
-    }
-    .search-overlay-back:active { opacity: 0.6; }
-    .search-overlay-back svg { width: 18px; height: 18px; }
-    .search-overlay-header .sinput { flex: 1; margin-bottom: 0; font-size: 16px; }
-    .search-overlay-list {
-      flex: 1; overflow-y: auto; -webkit-overflow-scrolling: touch;
-      overscroll-behavior: contain; padding: 8px 10px;
-      padding-bottom: max(16px, env(safe-area-inset-bottom, 16px));
-    }
-    .search-overlay-list .sugg-item { border-radius: 12px; border-bottom: none; margin-bottom: 2px; }
-    .search-overlay-list .sugg-item:hover, .search-overlay-list .sugg-item.active { background: var(--glass-tile-bg); }
   }
   @media (max-width: 768px) and (prefers-reduced-transparency: reduce) {
-    .panel, .show-btn, .theme-fab {
+    #search-pill, .theme-fab {
       backdrop-filter: none; -webkit-backdrop-filter: none;
       background: var(--glass-solid-fallback);
     }
-    .mode-tile { background: var(--glass-tile-bg); }
-    .mode-tile.active { background: var(--glass-tile-active); }
   }
   @media (prefers-reduced-motion: reduce) {
-    .panel, .show-btn, .theme-fab, .mode-tile { transition: none !important; }
+    #search-pill, .theme-fab { transition: none !important; }
   }


### PR DESCRIPTION
## Summary

- Strip the entire sidebar panel (desktop) and bottom sheet (mobile) — ~330 lines of HTML/CSS/JS deleted
- Add a floating search pill (`#search-pill`) that opens the full-screen search overlay on all screen sizes
- Introduce `setState()` state machine with `body[data-state]` to drive CSS visibility, replacing scattered `.view-menu`/`.view-travel`/`.view-postcode` class toggling
- Make search overlay universal (was mobile-only), remove the dual-input `overlaySourceInput` model
- Null-guard all references to deleted panel elements (`#st`, `#a5`–`#a20`, `#pc-input`) so `run()` and `setStatus()` don't crash

Closes #14. Phase 1 of the UX redesign (#10). Dependency for #13, #15, #16, #17.

## Test plan

- [ ] Desktop: pill visible top-left, click opens full-screen overlay, search + select draws isochrones
- [ ] Mobile (390×844): pill bottom-center, same search flow works
- [ ] Theme toggle works (top-right desktop, top-left mobile)
- [ ] No console errors on load or after search
- [ ] Dark/light mode: pill and overlay style correctly
- [ ] Verify on `dev.ldnmap.pages.dev` after deploy

🤖 Generated with [Claude Code](https://claude.ai/code)