### PR TITLE
feat: mode picker card after place selection (#15)

### DIFF
--- a/app.js
+++ b/app.js
@@ -109,11 +109,13 @@ var isoLayers = [];
 var mode = 'walking';
 var center = null;
 var postcodeLayer = null;
+var pendingPlace = null;
+var lastSearchQuery = '';
 
-function placeDefaultMarker() {
-  var lat = 51.5007, lng = -0.1246;
+function placeMarker(lat, lng) {
+  if (marker) map.removeLayer(marker);
   var markerFill = isDark ? '#fff' : '#1a1a1a';
-  var markerRing = isDark ? 'rgba(255,255,255,0.4)' : 'rgba(255,255,255,0.9)';
+  var markerRing = isDark ? 'rgba(255,255,255,0.4)' : 'rgba(0,0,0,0.3)';
   marker = L.circleMarker([lat, lng], {
     radius: 6, fillColor: markerFill, fillOpacity: 1,
     color: markerRing, weight: 8
@@ -124,10 +126,52 @@ map.on('mousemove', function(e) {
   document.getElementById('coords').textContent = e.latlng.lat.toFixed(4) + '°N, ' + e.latlng.lng.toFixed(4) + '°E';
 });
 
-function pick(m) {
-  mode = m;
-  document.querySelectorAll('.mbtn').forEach(function(b) { b.classList.toggle('on', b.dataset.m === m); });
-  if (center) run(center[0], center[1]);
+function showModePicker() {
+  if (!pendingPlace) return;
+  document.getElementById('mp-name').textContent = pendingPlace.name;
+  document.getElementById('mp-addr').textContent = pendingPlace.address;
+  var pcTile = document.getElementById('tile-postcode');
+  if (pcTile) {
+    pcTile.disabled = !pendingPlace.postcode;
+    pcTile.classList.toggle('mode-tile-soon', !pendingPlace.postcode);
+  }
+  setState('modepicker');
+}
+
+function activateMode(modeKey) {
+  if (!pendingPlace) return;
+  if (modeKey === 'walking' || modeKey === 'cycling' || modeKey === 'driving') {
+    mode = modeKey;
+    run(pendingPlace.lng, pendingPlace.lat, pendingPlace.name);
+  } else if (modeKey === 'postcode' && pendingPlace.postcode) {
+    searchPostcode(pendingPlace.postcode);
+  }
+  closeModePicker();
+}
+
+function closeModePicker() {
+  pendingPlace = null;
+  setState('idle');
+}
+
+function modePickerBack() {
+  if (marker) { map.removeLayer(marker); marker = null; }
+  openSearchOverlay();
+  var q = lastSearchQuery.trim();
+  overlayInput.value = lastSearchQuery;
+  if (q) {
+    pendingPostcode = PC_RE.test(q) ? formatPostcode(q) : null;
+    fetchSuggest(q);
+  }
+  pendingPlace = null;
+}
+
+function modePickerClose() {
+  if (marker) { map.removeLayer(marker); marker = null; }
+  isoLayers.forEach(function(l) { map.removeLayer(l); });
+  isoLayers = [];
+  pendingPlace = null;
+  setState('idle');
 }
 
 var sessionToken = (crypto && crypto.randomUUID) ? crypto.randomUUID() : String(Date.now()) + Math.random().toString(36).slice(2);
@@ -226,6 +270,7 @@ function selectSuggestionFromList(i, items) {
 
 async function selectSuggestion(s) {
   if (!s || !s.mapbox_id) return;
+  lastSearchQuery = overlayInput.value;
   closeSearchOverlay();
   setStatus('Loading…');
   try {
@@ -235,9 +280,14 @@ async function selectSuggestion(s) {
     var d = await r.json();
     if (d.features && d.features.length) {
       var c = d.features[0].geometry.coordinates;
-      var label = d.features[0].properties.full_address || s.name;
-      map.flyTo([c[1], c[0]], 13, { duration: 1.5 });
-      run(c[0], c[1], label);
+      var props = d.features[0].properties;
+      var name = s.name || props.name || '';
+      var address = props.full_address || s.place_formatted || '';
+      pendingPlace = { lng: c[0], lat: c[1], name: name, address: address, postcode: null };
+      map.flyTo([c[1], c[0]], 14, { duration: 1.5 });
+      placeMarker(c[1], c[0]);
+      setStatus(name);
+      showModePicker();
       sessionToken = (crypto && crypto.randomUUID) ? crypto.randomUUID() : String(Date.now()) + Math.random().toString(36).slice(2);
     } else { setStatus('Could not load that location', true); }
   } catch (e) { setStatus('Search failed', true); }
@@ -288,11 +338,7 @@ overlayInput.addEventListener('keydown', function(e) {
 async function run(lng, lat, label) {
   center = [lng, lat];
   setStatus('Loading isochrones…');
-
-  if (marker) map.removeLayer(marker);
-  var markerFill = isDark ? '#fff' : '#1a1a1a';
-  var markerRing = isDark ? 'rgba(255,255,255,0.4)' : 'rgba(0,0,0,0.3)';
-  marker = L.circleMarker([lat, lng], { radius: 6, fillColor: markerFill, fillOpacity: 1, color: markerRing, weight: 8 }).addTo(map);
+  placeMarker(lat, lng);
 
   isoLayers.forEach(function(l) { map.removeLayer(l); });
   isoLayers = [];

--- a/index.html
+++ b/index.html
@@ -34,6 +34,44 @@
   <div class="search-overlay-list" id="overlay-sugg"></div>
 </div>
 <div class="coord-display" id="coords">51.5007°N, 0.1246°W</div>
+<div id="mode-picker" class="mode-picker">
+  <div class="mode-picker-header">
+    <button class="mode-picker-back" onclick="modePickerBack()" aria-label="Back to search">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M19 12H5M12 19l-7-7 7-7"/>
+      </svg>
+    </button>
+    <div class="mode-picker-place">
+      <div class="mode-picker-name" id="mp-name"></div>
+      <div class="mode-picker-addr" id="mp-addr"></div>
+    </div>
+    <button class="mode-picker-close" onclick="modePickerClose()" aria-label="Close">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M18 6L6 18M6 6l12 12"/>
+      </svg>
+    </button>
+  </div>
+  <div class="mode-picker-tiles">
+    <button class="mode-tile" onclick="activateMode('walking')">
+      <span class="mode-tile-icon">🚶</span>
+      <span class="mode-tile-label">Travel time</span>
+    </button>
+    <button class="mode-tile" id="tile-postcode" onclick="activateMode('postcode')">
+      <span class="mode-tile-icon">📮</span>
+      <span class="mode-tile-label">Postcode</span>
+    </button>
+    <button class="mode-tile mode-tile-soon" disabled>
+      <span class="mode-tile-icon">🔍</span>
+      <span class="mode-tile-label">Nearby</span>
+      <span class="mode-tile-badge">Soon</span>
+    </button>
+    <button class="mode-tile mode-tile-soon" disabled>
+      <span class="mode-tile-icon">🎨</span>
+      <span class="mode-tile-label">Style</span>
+      <span class="mode-tile-badge">Soon</span>
+    </button>
+  </div>
+</div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.js"></script>
 <script src="app.js"></script>

--- a/style.css
+++ b/style.css
@@ -53,6 +53,7 @@
   #search-pill:active { transform: scale(0.97); }
   #search-pill svg { width: 18px; height: 18px; flex-shrink: 0; }
   body[data-state="search"] #search-pill { opacity: 0; pointer-events: none; }
+  body[data-state="modepicker"] #search-pill { opacity: 0; pointer-events: none; }
   #search-pill.icon-only .pill-label { display: none; }
   #search-pill.icon-only { padding: 0; width: 48px; justify-content: center; }
   .theme-fab {
@@ -122,6 +123,50 @@
   }
   .search-overlay-list .sugg-item { border-radius: 12px; border-bottom: none; margin-bottom: 2px; }
   .search-overlay-list .sugg-item:hover, .search-overlay-list .sugg-item.active { background: var(--glass-tile-bg); }
+  .mode-picker {
+    position: absolute; bottom: 60px; left: 16px; z-index: 1100;
+    width: 320px; border-radius: 20px;
+    background: var(--glass-pill-bg);
+    backdrop-filter: blur(40px) saturate(180%); -webkit-backdrop-filter: blur(40px) saturate(180%);
+    border: 1px solid var(--glass-border);
+    box-shadow: inset 0 1px 0 0 var(--glass-highlight), 0 4px 16px rgba(0,0,0,0.12);
+    padding: 16px;
+    opacity: 0; transform: translateY(16px); pointer-events: none;
+    transition: opacity 0.28s ease, transform 0.32s cubic-bezier(0.32, 0.72, 0, 1);
+  }
+  body[data-state="modepicker"] .mode-picker { opacity: 1; transform: translateY(0); pointer-events: auto; }
+  .mode-picker-header { display: flex; align-items: flex-start; gap: 10px; margin-bottom: 14px; }
+  .mode-picker-back, .mode-picker-close {
+    width: 32px; height: 32px; border-radius: 50%;
+    border: 1px solid var(--glass-border); background: var(--glass-tile-bg);
+    box-shadow: inset 0 1px 0 0 var(--glass-highlight);
+    color: var(--text); display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0; cursor: pointer;
+  }
+  .mode-picker-back:active, .mode-picker-close:active { opacity: 0.6; }
+  .mode-picker-back svg, .mode-picker-close svg { width: 16px; height: 16px; }
+  .mode-picker-place { flex: 1; min-width: 0; }
+  .mode-picker-name { font-size: 14px; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .mode-picker-addr { font-size: 11px; color: var(--text-dim); margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .mode-picker-tiles { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+  .mode-tile {
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 6px; padding: 16px 8px; border-radius: 14px;
+    border: 1px solid var(--glass-border); background: var(--glass-tile-bg);
+    color: var(--text); font-family: 'DM Sans', sans-serif;
+    cursor: pointer; transition: background 0.15s, transform 0.15s; position: relative;
+  }
+  .mode-tile:hover { background: var(--glass-tile-active); }
+  .mode-tile:active { transform: scale(0.96); }
+  .mode-tile-icon { font-size: 24px; }
+  .mode-tile-label { font-size: 12px; font-weight: 500; }
+  .mode-tile-soon { opacity: 0.4; cursor: default; pointer-events: none; }
+  .mode-tile-badge {
+    position: absolute; top: 6px; right: 6px;
+    font-size: 9px; font-weight: 600; color: var(--text-dim);
+    background: var(--glass-tile-bg); padding: 1px 5px; border-radius: 6px;
+    border: 1px solid var(--glass-border);
+  }
   @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
   @media (max-width: 768px) {
     #search-pill {
@@ -131,6 +176,11 @@
     .theme-fab { top: 12px; left: 12px; right: auto; }
     .coord-display { display: none; }
     .sinput { font-size: 16px; }
+    .mode-picker {
+      bottom: 0; left: 0; right: 0; width: auto;
+      border-radius: 20px 20px 0 0;
+      padding: 16px 16px max(16px, env(safe-area-inset-bottom, 16px));
+    }
   }
   @media (max-width: 768px) and (prefers-reduced-transparency: reduce) {
     #search-pill, .theme-fab {


### PR DESCRIPTION
## Summary
- After selecting a place from search, a **mode picker card** appears instead of immediately drawing isochrones
- Card shows place name/address with 4 mode tiles: Travel time, Postcode, Nearby (soon), Style (soon)
- **← back** returns to search overlay with previous query and suggestions restored
- **✕ close** clears the marker and dismisses the picker
- New `modepicker` app state drives card visibility via `body[data-state]` CSS
- Postcode tile is dynamically disabled for non-postcode place results
- Mobile: card renders as a full-width bottom sheet with safe-area padding
- Postcode selections from search still bypass the picker (direct boundary draw)

Closes #15

## Test plan
- [ ] Search "Big Ben" → select → mode picker appears with place name, marker on map
- [ ] Click "Travel time" → walking isochrones drawn, picker closes
- [ ] Click ← back → search overlay reopens with "Big Ben" and previous suggestions
- [ ] Click ✕ → picker closes, marker removed
- [ ] Search "SE1 7PB" → select postcode row → boundary drawn directly (no picker)
- [ ] "Nearby" and "Style" tiles visually muted and unclickable
- [ ] Mobile viewport: mode picker renders as bottom sheet
- [ ] Theme toggle: glass styling adapts correctly

🤖 Generated with [Claude Code](https://claude.ai/code)