### PR TITLE
feat: mobile search pill, dynamic proximity, overlay state restore (#17)

### DIFF
--- a/app.js
+++ b/app.js
@@ -236,6 +236,7 @@ var suggestTimer = null;
 var currentSuggestions = [];
 var activeIdx = -1;
 var pendingPostcode = null;
+var preSearchState = null;
 
 var overlayInput = document.getElementById('overlay-input');
 var overlaySugg = document.getElementById('overlay-sugg');
@@ -246,6 +247,7 @@ function closeSugg() { activeIdx = -1; }
 function openSugg() { if (currentSuggestions.length || pendingPostcode) renderSuggestions(); }
 
 function openSearchOverlay() {
+  preSearchState = appState;
   setState('search');
   overlayInput.value = '';
   overlayInput.placeholder = 'Search a place or postcode…';
@@ -264,7 +266,12 @@ function closeSearchOverlay() {
   pendingPostcode = null;
   currentSuggestions = [];
   overlaySugg.innerHTML = '';
-  setState('idle');
+  if (preSearchState === 'modepicker' && pendingPlace) {
+    setState('modepicker');
+  } else {
+    setState('idle');
+  }
+  preSearchState = null;
 }
 
 function formatPostcode(raw) {
@@ -296,8 +303,9 @@ function renderSuggestions() {
 
 async function fetchSuggest(q) {
   try {
+    var mc = map.getCenter();
     var url = 'https://api.mapbox.com/search/searchbox/v1/suggest?q=' + encodeURIComponent(q)
-      + '&language=en&country=gb&proximity=-0.0371,51.4871&limit=6'
+      + '&language=en&country=gb&proximity=' + mc.lng.toFixed(4) + ',' + mc.lat.toFixed(4) + '&limit=6'
       + '&session_token=' + sessionToken
       + '&access_token=' + MAPBOX_TOKEN;
     var r = await fetch(url);

--- a/style.css
+++ b/style.css
@@ -237,7 +237,17 @@
     }
     body[data-state="travel"] #search-pill,
     body[data-state="postcode"] #search-pill {
-      opacity: 0; pointer-events: none;
+      bottom: auto; top: 12px; left: 60px;
+      transform: none;
+      padding: 0; width: 48px; justify-content: center;
+    }
+    body[data-state="travel"] #search-pill .pill-label,
+    body[data-state="postcode"] #search-pill .pill-label {
+      display: none;
+    }
+    body[data-state="travel"] #search-pill:active,
+    body[data-state="postcode"] #search-pill:active {
+      transform: scale(0.97);
     }
   }
   @media (max-width: 768px) and (prefers-reduced-transparency: reduce) {


### PR DESCRIPTION
## Summary

Closes #17 — Mobile: search pill, full-screen overlay, and half-height mode picker sheet.

Integration gate for the unified search redesign chain (#14 → #13 → #15 → #16 → #17).

- **Mobile icon-only search pill**: In travel/postcode states, the search pill now collapses to a 48px icon at top-left (beside theme fab) instead of hiding completely — users can search again without closing the card first
- **Dynamic search proximity**: `fetchSuggest()` now uses `map.getCenter()` for Mapbox proximity bias instead of a hardcoded Clapham coordinate, so search results match wherever the user is viewing
- **Overlay state restore**: `closeSearchOverlay()` now restores the mode picker if the overlay was opened from that state (via `modePickerBack`) and `pendingPlace` still exists, instead of always resetting to idle

### iOS safe area — evaluated, no change needed
`viewport-fit=cover` is not set (per CLAUDE.md, must not add it). Browser handles safe areas automatically under `viewport-fit=auto`. Current padding values are adequate.

## Test plan

- [ ] Mobile (390×844): Idle → pill bottom-center with full label
- [ ] Mobile (390×844): Travel state → pill icon-only at top-left beside theme fab, tappable → opens overlay
- [ ] Mobile (390×844): Postcode state → same icon-only behavior
- [ ] Desktop (1280×800): No visual regressions
- [ ] Search bias: Pan to Canary Wharf, search "coffee" → results should be local
- [ ] State round-trip: Select place → mode picker → back → close overlay → returns to idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)