### PR TITLE
Merge dev → main: unified search redesign (#14, #13, #15, #16, #17)

### DIFF
--- a/app.js
+++ b/app.js
@@ -236,6 +236,7 @@ var suggestTimer = null;
 var currentSuggestions = [];
 var activeIdx = -1;
 var pendingPostcode = null;
+var preSearchState = null;
 
 var overlayInput = document.getElementById('overlay-input');
 var overlaySugg = document.getElementById('overlay-sugg');
@@ -246,6 +247,7 @@ function closeSugg() { activeIdx = -1; }
 function openSugg() { if (currentSuggestions.length || pendingPostcode) renderSuggestions(); }
 
 function openSearchOverlay() {
+  preSearchState = appState;
   setState('search');
   overlayInput.value = '';
   overlayInput.placeholder = 'Search a place or postcode…';
@@ -264,7 +266,12 @@ function closeSearchOverlay() {
   pendingPostcode = null;
   currentSuggestions = [];
   overlaySugg.innerHTML = '';
-  setState('idle');
+  if (preSearchState === 'modepicker' && pendingPlace) {
+    setState('modepicker');
+  } else {
+    setState('idle');
+  }
+  preSearchState = null;
 }
 
 function formatPostcode(raw) {
@@ -296,8 +303,9 @@ function renderSuggestions() {
 
 async function fetchSuggest(q) {
   try {
+    var mc = map.getCenter();
     var url = 'https://api.mapbox.com/search/searchbox/v1/suggest?q=' + encodeURIComponent(q)
-      + '&language=en&country=gb&proximity=-0.0371,51.4871&limit=6'
+      + '&language=en&country=gb&proximity=' + mc.lng.toFixed(4) + ',' + mc.lat.toFixed(4) + '&limit=6'
       + '&session_token=' + sessionToken
       + '&access_token=' + MAPBOX_TOKEN;
     var r = await fetch(url);

--- a/style.css
+++ b/style.css
@@ -237,7 +237,17 @@
     }
     body[data-state="travel"] #search-pill,
     body[data-state="postcode"] #search-pill {
-      opacity: 0; pointer-events: none;
+      bottom: auto; top: 12px; left: 60px;
+      transform: none;
+      padding: 0; width: 48px; justify-content: center;
+    }
+    body[data-state="travel"] #search-pill .pill-label,
+    body[data-state="postcode"] #search-pill .pill-label {
+      display: none;
+    }
+    body[data-state="travel"] #search-pill:active,
+    body[data-state="postcode"] #search-pill:active {
+      transform: scale(0.97);
     }
   }
   @media (max-width: 768px) and (prefers-reduced-transparency: reduce) {


### PR DESCRIPTION
## Summary

Promotes the full unified search redesign chain from `dev` to production:

- **#14** — Panel removal, search pill + overlay
- **#13** — Unified search with postcode regex detection
- **#15** — Mode picker card after place selection
- **#16** — Contextual mode controls (travel card + postcode chip)
- **#17** — Mobile polish: icon-only pill, dynamic proximity, overlay state restore

User-verified on real device via `dev.ldnmap.pages.dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)