### PR TITLE
fix: display small isochrone areas as km² with 2 decimal places (WCH-9)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,10 @@ Past failures: a one-line "zoom button blocked" complaint cascaded into 4 broken
 - **Reviewer disagreement → flag the structural difference** — if two reviewers propose mechanically different solutions (e.g. `top` vs `padding-top`), state explicitly which is a correctness issue vs a style preference. Don't treat them as equal options.
 - **Layered guesses → stop** — if the same visible bug has been shipped twice without resolution, the third attempt must not be another guess. Stop, request a fresh screenshot or live debug session.
 
+## Linear tickets
+
+Always assign new Linear tickets for this repo to the `ldnmap` project (project ID: `70541a2f-aa3f-45a7-824b-2e5b015bfb6f`, team: `wch`).
+
 ## iOS Safari + Leaflet gotchas (do not relearn the hard way)
 
 - iOS Safari **default `viewport-fit=auto` already keeps content inside the safe area**. `viewport-fit=cover` is a deliberate request to paint *under* the notch (immersive design only) — it is NOT a "turn on safe-area support" switch. Adding it makes content render under the status bar.

--- a/app.js
+++ b/app.js
@@ -428,7 +428,7 @@ async function run(lng, lat, label) {
       var el = document.getElementById('a' + m);
       if (!el) return;
       var a = areas[m];
-      if (a !== undefined && a > 0) { el.textContent = a >= 1 ? Math.round(a) + ' km²' : (a * 1000).toFixed(0) + ' m²'; el.classList.remove('empty'); }
+      if (a !== undefined && a > 0) { el.textContent = a >= 1 ? Math.round(a) + ' km²' : a.toFixed(2) + ' km²'; el.classList.remove('empty'); }
       else { el.textContent = '—'; el.classList.add('empty'); }
     });
 

--- a/app.js
+++ b/app.js
@@ -428,7 +428,7 @@ async function run(lng, lat, label) {
       var el = document.getElementById('a' + m);
       if (!el) return;
       var a = areas[m];
-      if (a !== undefined && a > 0) { el.textContent = a >= 1 ? Math.round(a) + ' km²' : a.toFixed(2) + ' km²'; el.classList.remove('empty'); }
+      if (a !== undefined && a > 0) { el.textContent = a >= 0.995 ? Math.round(a) + ' km²' : a.toFixed(2) + ' km²'; el.classList.remove('empty'); }
       else { el.textContent = '—'; el.classList.add('empty'); }
     });
 


### PR DESCRIPTION
## Summary

- Fixes WCH-9: area values < 1 km² were shown 1000× too small (e.g. "349 m²" instead of "0.35 km²")
- `ringArea()` returns km², so the sub-1 branch was multiplying by 1,000 instead of 1,000,000
- Fix: always render in km² — `Math.round()` for values ≥ 1, `.toFixed(2)` for values < 1

**Before:** 5 min → `349 m²` ❌  
**After:** 5 min → `0.35 km²` ✅

## Change

One line in `app.js:431`:
```js
// Before
a >= 1 ? Math.round(a) + ' km²' : (a * 1000).toFixed(0) + ' m²'

// After
a >= 1 ? Math.round(a) + ' km²' : a.toFixed(2) + ' km²'
```

## Test plan

- [ ] Search "Canary Wharf" → Walk → 5 min shows ~0.35 km² (not a 3-digit m² value)
- [ ] 10/15/20 min slots show proportionally larger values in km²
- [ ] Values ≥ 1 km² still show as rounded integers ("2 km²", not "2.00 km²")
- [ ] No "m²" string appears anywhere in the travel card
- [ ] Visual QA on `dev.ldnmap.pages.dev` at 390×844 and 1280×800

🤖 Generated with [Claude Code](https://claude.com/claude-code)