### PR TITLE
fix: area display km² fix (WCH-9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,10 @@ Past failures: a one-line "zoom button blocked" complaint cascaded into 4 broken
 - **Reviewer disagreement → flag the structural difference** — if two reviewers propose mechanically different solutions (e.g. `top` vs `padding-top`), state explicitly which is a correctness issue vs a style preference. Don't treat them as equal options.
 - **Layered guesses → stop** — if the same visible bug has been shipped twice without resolution, the third attempt must not be another guess. Stop, request a fresh screenshot or live debug session.
 
+## Linear tickets
+
+Always assign new Linear tickets for this repo to the `ldnmap` project (project ID: `70541a2f-aa3f-45a7-824b-2e5b015bfb6f`, team: `wch`).
+
 ## iOS Safari + Leaflet gotchas (do not relearn the hard way)
 
 - iOS Safari **default `viewport-fit=auto` already keeps content inside the safe area**. `viewport-fit=cover` is a deliberate request to paint *under* the notch (immersive design only) — it is NOT a "turn on safe-area support" switch. Adding it makes content render under the status bar.

--- a/app.js
+++ b/app.js
@@ -428,7 +428,7 @@ async function run(lng, lat, label) {
       var el = document.getElementById('a' + m);
       if (!el) return;
       var a = areas[m];
-      if (a !== undefined && a > 0) { el.textContent = a >= 1 ? Math.round(a) + ' km²' : (a * 1000).toFixed(0) + ' m²'; el.classList.remove('empty'); }
+      if (a !== undefined && a > 0) { el.textContent = a >= 1 ? Math.round(a) + ' km²' : a.toFixed(2) + ' km²'; el.classList.remove('empty'); }
       else { el.textContent = '—'; el.classList.add('empty'); }
     });
 

--- a/app.js
+++ b/app.js
@@ -428,7 +428,7 @@ async function run(lng, lat, label) {
       var el = document.getElementById('a' + m);
       if (!el) return;
       var a = areas[m];
-      if (a !== undefined && a > 0) { el.textContent = a >= 1 ? Math.round(a) + ' km²' : a.toFixed(2) + ' km²'; el.classList.remove('empty'); }
+      if (a !== undefined && a > 0) { el.textContent = a >= 0.995 ? Math.round(a) + ' km²' : a.toFixed(2) + ' km²'; el.classList.remove('empty'); }
       else { el.textContent = '—'; el.classList.add('empty'); }
     });
 


### PR DESCRIPTION
Promotes fix from dev → main.

- Fixes WCH-9: small isochrone areas were 1000× too small (e.g. "349 m²" instead of "0.35 km²")
- Uses `0.995` threshold to avoid "1.00 km²" boundary inconsistency
- User-verified on `dev.ldnmap.pages.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)