### PR TITLE
feat: postcode boundary → inline travel-time CTAs (WCH-11)

### DIFF
--- a/app.js
+++ b/app.js
@@ -211,6 +211,15 @@ function closePostcodeChip() {
   setState('idle');
 }
 
+function launchFromPostcode(modeKey) {
+  if (!pendingPlace) return;
+  if (postcodeLayer) { map.removeLayer(postcodeLayer); postcodeLayer = null; }
+  mode = modeKey;
+  updateModeButtons();
+  setState('travel');
+  run(pendingPlace.lng, pendingPlace.lat, pendingPlace.name);
+}
+
 function modePickerBack() {
   if (marker) { map.removeLayer(marker); marker = null; }
   openSearchOverlay();

--- a/app.js
+++ b/app.js
@@ -87,6 +87,7 @@ function renderPostcode(geo, pc) {
   if (pendingPlace && pendingPlace.postcode) {
     pendingPlace.lat = boundsCenter.lat;
     pendingPlace.lng = boundsCenter.lng;
+    document.querySelectorAll('.postcode-cta-btns .travel-mode-btn').forEach(function(b) { b.disabled = false; });
   }
 }
 
@@ -155,6 +156,7 @@ function activateMode(modeKey) {
     run(pendingPlace.lng, pendingPlace.lat, pendingPlace.name);
   } else if (modeKey === 'postcode' && pendingPlace.postcode) {
     document.getElementById('pc-label').textContent = pendingPlace.postcode;
+    document.querySelectorAll('.postcode-cta-btns .travel-mode-btn').forEach(function(b) { b.disabled = true; });
     setState('postcode');
     searchPostcode(pendingPlace.postcode);
   }

--- a/index.html
+++ b/index.html
@@ -79,6 +79,14 @@
       </svg>
     </button>
   </div>
+  <div class="postcode-cta-row">
+    <span class="postcode-cta-label">Travel time from here</span>
+    <div class="postcode-cta-btns">
+      <button class="travel-mode-btn" onclick="launchFromPostcode('walking')">🚶 Walk</button>
+      <button class="travel-mode-btn" onclick="launchFromPostcode('cycling')">🚴 Cycle</button>
+      <button class="travel-mode-btn" onclick="launchFromPostcode('driving')">🚗 Drive</button>
+    </div>
+  </div>
   <div class="postcode-chip-attrib">© OS data © Crown copyright 2025</div>
 </div>
 <div id="mode-picker" class="mode-picker">

--- a/style.css
+++ b/style.css
@@ -221,6 +221,10 @@
   .postcode-chip-label { font-size: 14px; font-weight: 600; color: #8b5cf6; }
   .postcode-chip-status { font-size: 11px; color: var(--text-dim); margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .postcode-chip-attrib { font-size: 9px; color: var(--text-faint); text-align: right; margin-top: 6px; }
+  .postcode-cta-row { margin-top: 10px; margin-bottom: 8px; display: flex; flex-direction: column; gap: 6px; }
+  .postcode-cta-label { font-size: 10px; font-weight: 500; color: var(--text-dim); letter-spacing: 0.02em; }
+  .postcode-cta-btns { display: flex; gap: 6px; }
+  .postcode-cta-btns .travel-mode-btn { flex: 1; }
   @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
   @media (max-width: 768px) {
     #search-pill {

--- a/style.css
+++ b/style.css
@@ -225,6 +225,7 @@
   .postcode-cta-label { font-size: 10px; font-weight: 500; color: var(--text-dim); letter-spacing: 0.02em; }
   .postcode-cta-btns { display: flex; gap: 6px; }
   .postcode-cta-btns .travel-mode-btn { flex: 1; }
+  .postcode-cta-btns .travel-mode-btn:disabled { opacity: 0.4; cursor: default; pointer-events: none; }
   @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
   @media (max-width: 768px) {
     #search-pill {


### PR DESCRIPTION
## Summary

- Adds Walk / Cycle / Drive buttons directly inside the postcode chip card
- Removes the purple boundary polygon before transitioning to isochrone view
- New `launchFromPostcode(modeKey)` bridges the `postcode` → `travel` state transition in one tap

## Changes

- `index.html` — CTA row with 3 buttons and "Travel time from here" label inserted into `#postcode-chip`
- `app.js` — `launchFromPostcode()` function: clears `postcodeLayer`, sets mode, calls `updateModeButtons()`, `setState('travel')`, and `run()`
- `style.css` — 4 new rules for `.postcode-cta-row`, `.postcode-cta-label`, `.postcode-cta-btns`

## Test plan

- [ ] Search a UK postcode (e.g. "EC2A 4BX") → select Postcode mode → chip shows boundary + 3 CTA buttons with "Travel time from here" label
- [ ] Tap Walk → purple polygon disappears, isochrone rings appear, travel card slides in with Walk tab active
- [ ] Tap Cycle / Drive → same flow, correct tab highlighted
- [ ] "Change mode" (← button) still navigates to mode picker unchanged
- [ ] Close (✕) still clears all and returns to idle
- [ ] Mobile 390×844: bottom sheet, buttons fill full width
- [ ] Desktop 1280×800: 320px card, buttons span card width

🤖 Generated with [Claude Code](https://claude.com/claude-code)